### PR TITLE
example of how to access list from Dispatcher.cpp

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -15,6 +15,11 @@ Dispatcher::Dispatcher(Parameters &parameters, Rcpp::Function &update_progress, 
   update_progress_ptr = &update_progress;
   args_progress_ptr = &args_progress;
   
+  // TODO - remove
+  vector<int> test1 = rcpp_to_vector_int(param_ptr->seed_list[0]);
+  print_vector(test1);
+  Rcpp::stop("foo1");
+  
   // make local copies of some parameters for convenience
   n_demes = param_ptr->n_demes;
   max_time = param_ptr->max_time;

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -30,10 +30,7 @@ Parameters::Parameters(const Rcpp::List &args) {
   H = rcpp_to_int(args["H"]);
   seed_infections = rcpp_to_vector_int(args["seed_infections"]);
   seed_vec = rcpp_to_vector_int(args["seed_vec"]);
-  Rcpp::List seed_list = args["seed_list"];
-  vector<int> test1 = rcpp_to_vector_int(seed_list["first"]);
-  print_vector(test1);
-//  Rcpp::stop("debug_list");
+  seed_list = args["seed_list"];
   M_vec = rcpp_to_vector_int(args["M"]);
   n_demes = int(M_vec.size());
   


### PR DESCRIPTION
The problem was that you were recreating the object inside parameters.cpp using e.g.
Rcpp::list seed_list = ...
Once you've created the object inside the header you don't need to do it again, so should be:
seed_list = ...

Once this is fixed you can access within Dispatcher.cpp, as demonstrated here. Also you should be fine using numerical indexing (no need for named list) as long as you use C++ style 0-based indexing.